### PR TITLE
Update image and action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+
+# ignore all files by default
+*
+# include required files with an exception
+!entrypoint.sh
+!LICENSE
+!README.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: joinflux/firebase-action
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            FIREBASE_VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          push: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.history/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14
+
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+LABEL com.github.actions.name="GitHub Action for Firebase"
+LABEL com.github.actions.description="Wraps the firebase-tools CLI to enable common commands."
+LABEL com.github.actions.icon="package"
+LABEL com.github.actions.color="gray-dark"
+
+ARG FIREBASE_VERSION=9.16.0
+RUN npm i -g firebase-tools@${FIREBASE_VERSION}
+
+COPY LICENSE README.md /
+COPY "entrypoint.sh" "/entrypoint.sh"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["--help"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Gustavo Hoirisch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# GitHub Actions for Firebase
+
+This Action for [firebase-tools](https://github.com/firebase/firebase-tools)
+enables arbitrary actions with the `firebase` command-line client and it provides
+a node environment with with firebase-tools installed and ready to be consumed.
+
+## Inputs
+
+* `args` - **Required**. This is the arguments you want to use for the `firebase` cli
+
+## Environment variables
+
+* `FIREBASE_TOKEN` - **Required if GCP_SA_KEY is not set**. The token to use for
+  authentication. This token can be aquired through the `firebase login:ci`
+  command.
+
+* `GCP_SA_KEY` - **Required if FIREBASE_TOKEN is not set**. A base64 encoded
+  private key (json format) for a Service Account with the `Firebase Admin` role
+  in the project. If you're deploying functions, you would also need the `Cloud
+  Functions Developer` role.  Since the deploy service account is using the App
+  Engine default service account in the deploy process, it also needs the
+  `Service Account User` role.  If you're only doing Hosting, `Firebase Hosting
+  Admin` is enough.
+
+* `PROJECT_ID` - **Optional**. To specify a specific project to use for all
+  commands. Not required if you specify a project in your `.firebaserc` file.
+
+* `PROJECT_PATH` - **Optional**. The path to the folder containing
+  `firebase.json` if it doesn't exist at the root of your repository. e.g.
+  `./my-app`
+
+## Example
+
+To authenticate with Firebase, and deploy to Firebase Hosting:
+
+```yaml
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Install Dependencies
+        run: npm install
+      - name: Build
+        run: npm run build-prod
+      - name: Archive Production Artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: dist
+          path: dist
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Download Artifact
+        uses: actions/download-artifact@master
+        with:
+          name: dist
+          path: dist
+      - name: Deploy to Firebase
+        uses: joinflux/firebase-action@master
+        with:
+          args: deploy --only hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+```
+Alternatively:
+
+```yaml
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+```
+
+
+If you have multiple hosting environments you can specify which one in the args line. 
+e.g. `args: deploy --only hosting:[environment name]`
+
+If you want to add a message to a deployment (e.g. the Git commit message) you need to take extra care and escape the quotes or the YAML breaks.
+
+```yaml
+        with:
+          args: deploy --message \"${{ github.event.head_commit.message }}\"
+```
+
+### Running a script
+
+If you'd like to run a script that depends on `firebase-tools`, simply use the
+relative path to the script:
+
+```js
+// ./my-script.js 
+const firebase = require("firebase-tools")
+// do something with firebase
+```
+
+```yaml
+      - name: Run script
+        uses: joinflux/firebase-action@9.16.0
+        with:
+          args: "./my-script.sh"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+```
+
+## License
+
+The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).
+
+
+### Recommendation
+
+If you decide to do seperate jobs for build and deployment (which is probably advisable), then make sure to clone your repo as the Firebase-cli requires the firebase repo to deploy (specifically the `firebase.json`)

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,9 @@
+name: 'firebase-tools'
+author: 'Gustavo Hoirisch'
+description: 'Wraps the firebase-tools CLI to enable common commands or to be used in a script.'
+branding:
+  icon: 'package'
+  color: 'gray-dark'
+runs:
+  using: 'docker'
+  image: 'docker://joinflux/firebase-action:9.16.0'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$FIREBASE_TOKEN" ] && [ -z "$GCP_SA_KEY" ]; then
+  echo "Either FIREBASE_TOKEN or GCP_SA_KEY is required to run commands with the firebase cli"
+  exit 126
+fi
+
+if [ -n "$GCP_SA_KEY" ]; then
+  echo "Storing GCP_SA_KEY in /opt/gcp_key.json"
+  echo "$GCP_SA_KEY" | base64 -d > /opt/gcp_key.json
+  echo "Exporting GOOGLE_APPLICATION_CREDENTIALS=/opt/gcp_key.json"
+  export GOOGLE_APPLICATION_CREDENTIALS=/opt/gcp_key.json
+fi
+
+if [ -n "$PROJECT_PATH" ]; then
+  cd "$PROJECT_PATH"
+fi
+
+if [ -n "$PROJECT_ID" ]; then
+    echo "setting firebase project to $PROJECT_ID"
+    firebase use --add "$PROJECT_ID"
+fi
+
+# if the args starts with ./ we are running a script
+case "$*" in
+  ./*) sh -c "$*";;
+  *) sh -c "firebase $*";;
+esac

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,15 @@
+#!/bin/sh
+# script/bootstrap: Resolve dependencies that the application requires to run.
+
+# Exit if any subcommand fails
+set -e
+
+# Ensure we're always running from the project root
+cd "$(dirname "$0")/.."
+
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  brew bundle check >/dev/null 2>&1  || {
+    echo "==> Installing Homebrew dependencies…"
+    brew bundle
+  }
+fi

--- a/script/test
+++ b/script/test
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Exit if any subcommand fails
+set -e
+
+# Ensure we're always running from the project root
+cd "$(dirname "$0")/.."
+
+bats test/*.bats
+shellcheck *.sh

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+PATH="$PATH:$BATS_TEST_DIRNAME/bin"
+
+function setup() {
+  # Ensure GITHUB_WORKSPACE is set
+  export GITHUB_WORKSPACE="${GITHUB_WORKSPACE-"${BATS_TEST_DIRNAME}/.."}"
+}
+
+@test "entrypoint runs successfully" {
+  run $GITHUB_WORKSPACE/entrypoint.sh --help
+  echo "$output"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This PR removes the emulators dependencies from the Dockerfile. It also allows us
for dynamically pinning the firebase-tools installation and links its version
 number with the Docker image tag.
 
This means that image version: 9.16.0 has firebase-tools 9.16.0.

Finally it also adds the options of running commands that are not from the
"firebase" cli.

